### PR TITLE
Handle previously selected mascot falling outside of mascot list

### DIFF
--- a/builds/OneeChan.user.js
+++ b/builds/OneeChan.user.js
@@ -4048,6 +4048,12 @@
             } else
                 var mascot = $SS.conf["Mascots"][index];
 
+            if (mascot == undefined){
+                this.img = new $SS.Image(null);
+                this.hidden = true;
+                return;
+            }
+
             this.index = index;
             this.hidden = $SS.conf["Hidden Mascots"].indexOf(index) !== -1;
             this.default = mascot.default;


### PR DESCRIPTION
Related to #18  if the previously selected mascot was the last mascot on the list and a mascot was removed, OneeChan fails to start with error "TypeError 'mascot' is undefined" in the browser console