### PR TITLE
Remove more mascots button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### v5.9.0
+*2024-02-28*
+
+- Removed more mascots button.
+
 ### v5.8.9
 *2019-07-24*
 

--- a/src/script.js
+++ b/src/script.js
@@ -1423,7 +1423,6 @@
                     p = $("<p class='buttons-container'>");
 
                 p.append($("<a class='options-button' name=addMascot title='Add a new mascot.'>Add", tOptions).bind("click", $SS.options.showMascot));
-                p.append($("<a class='options-button' href='http://appchan.booru.org/' title='Get more mascots. Possibly NSFW.' target='_blank'>More Mascots"));
                 p.append($("<a class='options-button' name=restoreMascots title='Restore hidden default mascots'>Restore", tOptions)
                     .bind("click", function() {
                         $SS.conf["Hidden Mascots"] = [];


### PR DESCRIPTION
Removed the more mascot buttons because it points to a dead website. We should decide whether to point to an archived link or something else; but for now this does the job.